### PR TITLE
Parks trails links

### DIFF
--- a/app/views/park_trails/index.html.erb
+++ b/app/views/park_trails/index.html.erb
@@ -1,3 +1,4 @@
+<a href="/parks">Parks Index</a>
 <a href="/trails">Trails Index</a>
 
 <% @trails.each do |trail| %>

--- a/app/views/park_trails/index.html.erb
+++ b/app/views/park_trails/index.html.erb
@@ -1,3 +1,5 @@
+<a href="/trails">Trails Index</a>
+
 <% @trails.each do |trail| %>
   <h3><%= trail.name %></h3>
   <p>Length: <%= trail.length %></p>

--- a/app/views/parks/index.html.erb
+++ b/app/views/parks/index.html.erb
@@ -1,3 +1,5 @@
+<a href="/trails">Trails Index</a>
+
 <h1>All Parks</h1>
 <% @parks.each do |park| %>
   <h3><%= park.name %></h3>

--- a/app/views/parks/show.html.erb
+++ b/app/views/parks/show.html.erb
@@ -1,3 +1,4 @@
+<a href="/parks">Parks Index</a>
 <a href="/trails">Trails Index</a>
 
 <h1><%= @park.name %></h1>

--- a/app/views/parks/show.html.erb
+++ b/app/views/parks/show.html.erb
@@ -1,3 +1,5 @@
+<a href="/trails">Trails Index</a>
+
 <h1><%= @park.name %></h1>
 <p>State: <%= @park.state %></p>
 <p>County: <%= @park.county %></p>

--- a/app/views/parks/show.html.erb
+++ b/app/views/parks/show.html.erb
@@ -1,7 +1,7 @@
 <a href="/parks">Parks Index</a>
 <a href="/trails">Trails Index</a>
 
-<h1><%= @park.name %></h1>
+<h1><%= link_to @park.name, "/parks/#{@park.id}/trails" %></h1>
 <p>State: <%= @park.state %></p>
 <p>County: <%= @park.county %></p>
 <p>Parking Fee: $<%= @park.parking_fee %></p>

--- a/app/views/trails/index.html.erb
+++ b/app/views/trails/index.html.erb
@@ -1,3 +1,5 @@
+<a href="/parks">Parks Index</a>
+
 <h1>All Trails</h1>
 <% @trails.each do |trail| %>
   <h3><%= trail.name %></h3>

--- a/app/views/trails/show.html.erb
+++ b/app/views/trails/show.html.erb
@@ -1,3 +1,5 @@
+<a href="/trails">Trails Index</a>
+
 <h1><%= @trail.name %></h1>
 <p>Length: <%= @trail.length %></p>
 <p>Elevation Gain: <%= @trail.elevation_gain %></p>

--- a/app/views/trails/show.html.erb
+++ b/app/views/trails/show.html.erb
@@ -1,3 +1,4 @@
+<a href="/parks">Parks Index</a>
 <a href="/trails">Trails Index</a>
 
 <h1><%= @trail.name %></h1>

--- a/spec/features/parks/index_spec.rb
+++ b/spec/features/parks/index_spec.rb
@@ -45,4 +45,16 @@ RSpec.describe 'Park index' do
 
     expect(park_2.name).to appear_before(park_1.name)
   end
+
+  # User Story 8:
+  # As a visitor
+  # When I visit any page on the site
+  # Then I see a link at the top of the page that takes me to the Child Index
+  it 'shows link to the trails index' do
+    visit '/parks'
+
+    click_on "Trails Index"
+
+    expect(current_path).to eq('/trails')
+  end
 end

--- a/spec/features/parks/show_spec.rb
+++ b/spec/features/parks/show_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'User Story 2 - Park Show' do
                         county: "Jefferson",
                         parking_fee: 0,
                         dogs_allowed: true)
-                        
+
     visit "/parks/#{park.id}"
 
     expect(page).to have_content(park.name)
@@ -61,5 +61,23 @@ RSpec.describe 'User Story 2 - Park Show' do
     click_on "Trails Index"
 
     expect(current_path).to eq('/trails')
+  end
+
+  # User Story 9:
+  # As a visitor
+  # When I visit any page on the site
+  # Then I see a link at the top of the page that takes me to the Parent Index
+  it 'shows link to the parks index' do
+    park = Park.create!(name: "North Table Mountain",
+                        state: "CO",
+                        county: "Jefferson",
+                        parking_fee: 0,
+                        dogs_allowed: true)
+
+    visit "/parks/#{park.id}"
+
+    click_on "Parks Index"
+
+    expect(current_path).to eq('/parks')
   end
 end

--- a/spec/features/parks/show_spec.rb
+++ b/spec/features/parks/show_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'User Story 2 - Park Show' do
                         county: "Jefferson",
                         parking_fee: 0,
                         dogs_allowed: true)
+                        
     visit "/parks/#{park.id}"
 
     expect(page).to have_content(park.name)
@@ -38,8 +39,27 @@ RSpec.describe 'User Story 2 - Park Show' do
                           length: 5280,
                           elevation_gain: 320,
                           loop: false)
+
     visit "/parks/#{park.id}"
 
     expect(page).to have_content("#{park.trails.length} Trails")
+  end
+
+  # User Story 8:
+  # As a visitor
+  # When I visit any page on the site
+  # Then I see a link at the top of the page that takes me to the Child Index
+  it 'shows link to the trails index' do
+    park = Park.create!(name: "North Table Mountain",
+                        state: "CO",
+                        county: "Jefferson",
+                        parking_fee: 0,
+                        dogs_allowed: true)
+
+    visit "/parks/#{park.id}"
+
+    click_on "Trails Index"
+
+    expect(current_path).to eq('/trails')
   end
 end

--- a/spec/features/parks/show_spec.rb
+++ b/spec/features/parks/show_spec.rb
@@ -80,4 +80,23 @@ RSpec.describe 'User Story 2 - Park Show' do
 
     expect(current_path).to eq('/parks')
   end
+
+
+  # User Story 10, Parent Child Index Link
+  # As a visitor
+  # When I visit a parent show page ('/parents/:id')
+  # Then I see a link to take me to that parent's `child_table_name` page ('/parents/:id/child_table_name')
+  it 'shows link to the parks index' do
+    park = Park.create!(name: "North Table Mountain",
+                        state: "CO",
+                        county: "Jefferson",
+                        parking_fee: 0,
+                        dogs_allowed: true)
+
+    visit "/parks/#{park.id}"
+
+    click_on "#{park.name}"
+
+    expect(current_path).to eq("/parks/#{park.id}/trails")
+  end
 end

--- a/spec/features/parks/trails/index_spec.rb
+++ b/spec/features/parks/trails/index_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe 'User Story 5 - Parks trails index' do
                           length: 5280,
                           elevation_gain: 320,
                           loop: false)
+                          
     visit "/parks/#{park.id}/trails"
 
     expect(page).to have_content(trail_1.name)
@@ -28,5 +29,27 @@ RSpec.describe 'User Story 5 - Parks trails index' do
     expect(page).to have_content("Elevation Gain: #{trail_2.elevation_gain}")
     expect(page).to have_content("Loop: #{trail_1.loop}")
     expect(page).to have_content("Loop: #{trail_2.loop}")
+  end
+
+  # User Story 8:
+  # As a visitor
+  # When I visit any page on the site
+  # Then I see a link at the top of the page that takes me to the Child Index
+  it 'shows link to the trails index' do
+    park = Park.create!(name: "North Table Mountain",
+                        state: "CO",
+                        county: "Jefferson",
+                        parking_fee: 0,
+                        dogs_allowed: true)
+    # trail = park.trails.create!(name: "North Table Loop",
+    #                       length: 38016,
+    #                       elevation_gain: 1059,
+    #                       loop: true)
+
+    visit "/parks/#{park.id}/trails"
+
+    click_on "Trails Index"
+
+    expect(current_path).to eq('/trails')
   end
 end

--- a/spec/features/parks/trails/index_spec.rb
+++ b/spec/features/parks/trails/index_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'User Story 5 - Parks trails index' do
                           length: 5280,
                           elevation_gain: 320,
                           loop: false)
-                          
+
     visit "/parks/#{park.id}/trails"
 
     expect(page).to have_content(trail_1.name)
@@ -41,15 +41,29 @@ RSpec.describe 'User Story 5 - Parks trails index' do
                         county: "Jefferson",
                         parking_fee: 0,
                         dogs_allowed: true)
-    # trail = park.trails.create!(name: "North Table Loop",
-    #                       length: 38016,
-    #                       elevation_gain: 1059,
-    #                       loop: true)
 
     visit "/parks/#{park.id}/trails"
 
     click_on "Trails Index"
 
     expect(current_path).to eq('/trails')
+  end
+
+  # User Story 9:
+  # As a visitor
+  # When I visit any page on the site
+  # Then I see a link at the top of the page that takes me to the Parent Index
+  it 'shows link to the parks index' do
+    park = Park.create!(name: "North Table Mountain",
+                        state: "CO",
+                        county: "Jefferson",
+                        parking_fee: 0,
+                        dogs_allowed: true)
+
+    visit "/parks/#{park.id}/trails"
+
+    click_on "Parks Index"
+
+    expect(current_path).to eq('/parks')
   end
 end

--- a/spec/features/trails/index_spec.rb
+++ b/spec/features/trails/index_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe 'User Story 3 - Trails index' do
                           length: 5280,
                           elevation_gain: 320,
                           loop: false)
+
     visit '/trails'
 
     expect(page).to have_content(trail_1.name)
@@ -28,5 +29,17 @@ RSpec.describe 'User Story 3 - Trails index' do
     expect(page).to have_content(trail_2.elevation_gain)
     expect(page).to have_content(trail_1.loop)
     expect(page).to have_content(trail_2.loop)
+  end
+
+  # User Story 9:
+  # As a visitor
+  # When I visit any page on the site
+  # Then I see a link at the top of the page that takes me to the Parent Index
+  it 'shows link to the parks index' do
+    visit "/trails"
+
+    click_on "Parks Index"
+
+    expect(current_path).to eq('/parks')
   end
 end

--- a/spec/features/trails/show_spec.rb
+++ b/spec/features/trails/show_spec.rb
@@ -14,11 +14,34 @@ RSpec.describe 'User Story 4 - Trails Show' do
                           length: 38016,
                           elevation_gain: 1059,
                           loop: true)
+
     visit "/trails/#{trail.id}"
 
     expect(page).to have_content(trail.name)
     expect(page).to have_content("Length: #{trail.length}")
     expect(page).to have_content("Elevation Gain: #{trail.elevation_gain}")
     expect(page).to have_content("Loop: #{trail.loop}")
+  end
+
+  # User Story 8:
+  # As a visitor
+  # When I visit any page on the site
+  # Then I see a link at the top of the page that takes me to the Child Index
+  it 'shows link to the trails index' do
+    park = Park.create!(name: "North Table Mountain",
+                        state: "CO",
+                        county: "Jefferson",
+                        parking_fee: 0,
+                        dogs_allowed: true)
+    trail = park.trails.create!(name: "North Table Loop",
+                          length: 38016,
+                          elevation_gain: 1059,
+                          loop: true)
+
+    visit "/trails/#{trail.id}"
+
+    click_on "Trails Index"
+
+    expect(current_path).to eq('/trails')
   end
 end

--- a/spec/features/trails/show_spec.rb
+++ b/spec/features/trails/show_spec.rb
@@ -44,4 +44,26 @@ RSpec.describe 'User Story 4 - Trails Show' do
 
     expect(current_path).to eq('/trails')
   end
+
+  # User Story 9:
+  # As a visitor
+  # When I visit any page on the site
+  # Then I see a link at the top of the page that takes me to the Parent Index
+  it 'shows link to the parks index' do
+    park = Park.create!(name: "North Table Mountain",
+                        state: "CO",
+                        county: "Jefferson",
+                        parking_fee: 0,
+                        dogs_allowed: true)
+    trail = park.trails.create!(name: "North Table Loop",
+                          length: 38016,
+                          elevation_gain: 1059,
+                          loop: true)
+
+    visit "/trails/#{trail.id}"
+
+    click_on "Parks Index"
+
+    expect(current_path).to eq('/parks')
+  end
 end


### PR DESCRIPTION
What I Did:
- Add parks index link to all pages except parks index
- Add trails index link to all pages except trails index
- Add parks trails index to parks show page

Roadblocks:
- There has to be an easier way to add links to all pages without adding to each page individually

Tests:
- 100% coverage

Notes:
- Iteration 1 complete except for refactor
- Will refactor while working on iteration 2