### PR TITLE
Add index links for parent and children views

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,13 @@
   </head>
 
   <body>
+    <!-- Need to add rspec assertions in app_spec for these (user stories 8-10) -->
+    <%= link_to "Parks Index", "/parks" %>&nbsp;
+    <%= link_to "Trails Index", "/trails" %>&nbsp;
+    <%= link_to "Regions Index", "/regions" %>&nbsp;
+    <%= link_to "Resorts Index", "/resorts" %>&nbsp;
+    <!-- <%= link_to "Ski Brands Index", "/ski_brands" %>&nbsp; -->
+    <!-- <%= link_to "Skis Index", "/skis" %>&nbsp; -->
     <%= yield %>
   </body>
 </html>

--- a/app/views/park_trails/index.html.erb
+++ b/app/views/park_trails/index.html.erb
@@ -1,5 +1,5 @@
-<a href="/parks">Parks Index</a>
-<a href="/trails">Trails Index</a>
+<!-- <a href="/parks">Parks Index</a>
+<a href="/trails">Trails Index</a> -->
 
 <% @trails.each do |trail| %>
   <h3><%= trail.name %></h3>

--- a/app/views/parks/index.html.erb
+++ b/app/views/parks/index.html.erb
@@ -1,4 +1,4 @@
-<a href="/trails">Trails Index</a>
+<!-- <a href="/trails">Trails Index</a> -->
 
 <h1>All Parks</h1>
 <% @parks.each do |park| %>

--- a/app/views/parks/show.html.erb
+++ b/app/views/parks/show.html.erb
@@ -1,5 +1,5 @@
-<a href="/parks">Parks Index</a>
-<a href="/trails">Trails Index</a>
+<!-- <a href="/parks">Parks Index</a>
+<a href="/trails">Trails Index</a> -->
 
 <h1><%= link_to @park.name, "/parks/#{@park.id}/trails" %></h1>
 <p>State: <%= @park.state %></p>

--- a/app/views/regions/index.html.erb
+++ b/app/views/regions/index.html.erb
@@ -7,6 +7,6 @@
 
 <br><br>
 
-<form style="float:left; padding-left:1px;" action="/resorts">
+<!-- <form style="float:left; padding-left:1px;" action="/resorts">
   <input type="submit" value="Resorts Index"/>
-</form>
+</form> -->

--- a/app/views/regions/resorts.html.erb
+++ b/app/views/regions/resorts.html.erb
@@ -1,7 +1,7 @@
-<form style="float:left; padding-top:5px;" action="/regions">
+<!-- <form style="float:left; padding-top:5px;" action="/regions">
   <input type="submit" value="Regions Index"/>
 </form>
-<br>
+<br> -->
 
 
 <h2><%= link_to @region.name, "/regions/#{@region.id}" %></h2>

--- a/app/views/regions/show.html.erb
+++ b/app/views/regions/show.html.erb
@@ -1,16 +1,15 @@
-<form style="float:left; padding-top:5px;" action="/regions">
+<!-- <form style="float:left; padding-top:5px;" action="/regions">
   <input type="submit" value="Regions Index"/>
 </form>
-<br><br>
+<br><br> -->
 
+
+<h1><%= @region.name %></h1>
 <% if @region.resorts.length == 1 %>
   <%= link_to "View All (#{@region.resorts.length}) Resort", "/regions/#{@region.id}/resorts" %>
 <% else %>
   <%= link_to "View All (#{@region.resorts.length}) Resorts", "/regions/#{@region.id}/resorts" %>
 <% end %>
-
-
-<h1><%= @region.name %></h1>
 
 <p>Priority: <%= @region.priority %></p>
 <p>Currently Active: <%= @region.active %></p>

--- a/app/views/resorts/index.html.erb
+++ b/app/views/resorts/index.html.erb
@@ -1,7 +1,7 @@
-<form style="float:left; padding-top:5px;" action="/regions">
+<!-- <form style="float:left; padding-top:5px;" action="/regions">
   <input type="submit" value="Regions Index"/>
 </form>
-<br>
+<br> -->
 
 
 <h1>Resorts Index</h1>

--- a/app/views/resorts/show.html.erb
+++ b/app/views/resorts/show.html.erb
@@ -1,7 +1,7 @@
-<form style="float:left; padding-top:5px;" action="/resorts">
+<!-- <form style="float:left; padding-top:5px;" action="/resorts">
   <input type="submit" value="Resorts Index"/>
 </form>
-<br>
+<br> -->
 
 
 <h1><%= @resort.name %></h1>

--- a/app/views/trails/index.html.erb
+++ b/app/views/trails/index.html.erb
@@ -1,4 +1,4 @@
-<a href="/parks">Parks Index</a>
+<!-- <a href="/parks">Parks Index</a> -->
 
 <h1>All Trails</h1>
 <% @trails.each do |trail| %>

--- a/app/views/trails/show.html.erb
+++ b/app/views/trails/show.html.erb
@@ -1,5 +1,5 @@
-<a href="/parks">Parks Index</a>
-<a href="/trails">Trails Index</a>
+<!-- <a href="/parks">Parks Index</a>
+<a href="/trails">Trails Index</a> -->
 
 <h1><%= @trail.name %></h1>
 <p>Length: <%= @trail.length %></p>

--- a/spec/features/app_spec.rb
+++ b/spec/features/app_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+
+RSpec.describe 'application layout' do
+# User Story 8, Child Index Link
+  # As a visitor
+  # When I visit any page on the site
+  # Then I see a link at the top of the page that takes me to the Child Index
+  describe 'links to all child indexes' do
+    it 'links to trails index' do
+      park = Park.create!(name: "North Table Mountain",
+                          state: "CO",
+                          county: "Jefferson",
+                          parking_fee: 0,
+                          dogs_allowed: true)
+
+      visit "/parks"
+      # save_and_open_page
+
+      click_on "Trails Index"
+      expect(current_path).to eq("/trails")
+
+      visit "/regions"
+      click_on "Trails Index"
+      expect(current_path).to eq("/trails")
+    end
+    it 'links to resorts index' do
+      region = Region.create!(
+        name: 'US - Rocky Mountain',
+        active: true,
+        rvp_operations: 'Fred "Shreddy" McGnar',
+        priority: 1)
+
+      visit "/regions"
+      # save_and_open_page
+
+      click_on "Resorts Index"
+      expect(current_path).to eq("/resorts")
+
+      visit "/parks"
+      click_on "Resorts Index"
+      expect(current_path).to eq("/resorts")
+    end
+    xit 'links to skis index' do
+      # stuff
+    end
+  end
+
+# User Story 9, Parent Index Link
+  # As a visitor
+  # When I visit any page on the site
+  # Then I see a link at the top of the page that takes me to the Parent Index
+  describe 'links to all parent indexes' do
+    it 'links to parks index' do
+      park = Park.create!(name: "North Table Mountain",
+                          state: "CO",
+                          county: "Jefferson",
+                          parking_fee: 0,
+                          dogs_allowed: true)
+      trail = park.trails.create!(name: "North Table Loop",
+                            length: 38016,
+                            elevation_gain: 1059,
+                            loop: true)
+
+      visit "/trails"
+      # save_and_open_page
+
+      click_on "Parks Index"
+      expect(current_path).to eq("/parks")
+
+      visit "/resorts"
+      click_on "Parks Index"
+      expect(current_path).to eq("/parks")
+    end
+    it 'links to regions index' do
+      region = Region.create!(
+        name: 'US - Rocky Mountain',
+        active: true,
+        rvp_operations: 'Fred "Shreddy" McGnar',
+        priority: 1)
+      resort = region.resorts.create!(
+        name: 'Crested Butte',
+        country: 'United States',
+        state_province: 'CO',
+        active: true,
+        director_operations: 'Molly Hauck',
+        ttm_revenue_usd: 170530257)
+
+      visit "/resorts"
+      # save_and_open_page
+
+      click_on "Regions Index"
+      expect(current_path).to eq("/regions")
+
+      visit "/parks"
+      click_on "Regions Index"
+      expect(current_path).to eq("/regions")
+    end
+    xit 'links to ski brands index' do
+      # stuff
+    end
+  end
+
+end

--- a/spec/features/parks/show_spec.rb
+++ b/spec/features/parks/show_spec.rb
@@ -45,41 +45,41 @@ RSpec.describe 'User Story 2 - Park Show' do
     expect(page).to have_content("#{park.trails.length} Trails")
   end
 
-  # User Story 8:
-  # As a visitor
-  # When I visit any page on the site
-  # Then I see a link at the top of the page that takes me to the Child Index
-  it 'shows link to the trails index' do
-    park = Park.create!(name: "North Table Mountain",
-                        state: "CO",
-                        county: "Jefferson",
-                        parking_fee: 0,
-                        dogs_allowed: true)
-
-    visit "/parks/#{park.id}"
-
-    click_on "Trails Index"
-
-    expect(current_path).to eq('/trails')
-  end
-
-  # User Story 9:
-  # As a visitor
-  # When I visit any page on the site
-  # Then I see a link at the top of the page that takes me to the Parent Index
-  it 'shows link to the parks index' do
-    park = Park.create!(name: "North Table Mountain",
-                        state: "CO",
-                        county: "Jefferson",
-                        parking_fee: 0,
-                        dogs_allowed: true)
-
-    visit "/parks/#{park.id}"
-
-    click_on "Parks Index"
-
-    expect(current_path).to eq('/parks')
-  end
+  # # User Story 8:
+  # # As a visitor
+  # # When I visit any page on the site
+  # # Then I see a link at the top of the page that takes me to the Child Index
+  # it 'shows link to the trails index' do
+  #   park = Park.create!(name: "North Table Mountain",
+  #                       state: "CO",
+  #                       county: "Jefferson",
+  #                       parking_fee: 0,
+  #                       dogs_allowed: true)
+  #
+  #   visit "/parks/#{park.id}"
+  #
+  #   click_on "Trails Index"
+  #
+  #   expect(current_path).to eq('/trails')
+  # end
+  #
+  # # User Story 9:
+  # # As a visitor
+  # # When I visit any page on the site
+  # # Then I see a link at the top of the page that takes me to the Parent Index
+  # it 'shows link to the parks index' do
+  #   park = Park.create!(name: "North Table Mountain",
+  #                       state: "CO",
+  #                       county: "Jefferson",
+  #                       parking_fee: 0,
+  #                       dogs_allowed: true)
+  #
+  #   visit "/parks/#{park.id}"
+  #
+  #   click_on "Parks Index"
+  #
+  #   expect(current_path).to eq('/parks')
+  # end
 
 
   # User Story 10, Parent Child Index Link

--- a/spec/features/regions/resorts_spec.rb
+++ b/spec/features/regions/resorts_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe "region's resorts index" do
 
     visit "/regions/#{region.id}/resorts"
     # save_and_open_page
-    click_button 'Regions Index'
+    click_on 'Regions Index'
 
     expect(current_path).to eq('/regions')
   end

--- a/spec/features/regions/show_spec.rb
+++ b/spec/features/regions/show_spec.rb
@@ -98,7 +98,25 @@ RSpec.describe 'region show page' do
     end
   end
 
-  it 'displays a button to return to the parent index from the show page' do
+  # it 'displays a button to return to the parent index from the show page' do
+  #   region = Region.create!(
+  #     name: 'US - Rocky Mountain',
+  #     active: true,
+  #     rvp_operations: 'Fred "Shreddy" McGnar',
+  #     priority: 1)
+  #
+  #   visit "/regions/#{region.id}"
+  #   # save_and_open_page
+  #
+  #   click_button 'Regions Index'
+  #   expect(current_path).to eq('/regions')
+  # end
+
+# User Story 10, Parent Child Index Link
+  # As a visitor
+  # When I visit a parent show page ('/parents/:id')
+  # Then I see a link to take me to that parent's `child_table_name` page ('/parents/:id/child_table_name')
+  it 'shows link to the regions index' do
     region = Region.create!(
       name: 'US - Rocky Mountain',
       active: true,
@@ -108,8 +126,8 @@ RSpec.describe 'region show page' do
     visit "/regions/#{region.id}"
     # save_and_open_page
 
-    click_button 'Regions Index'
-    expect(current_path).to eq('/regions')
+    click_on "View All (#{region.resorts.length}) Resorts"
+    expect(current_path).to eq("/regions/#{region.id}/resorts")
   end
 
 end

--- a/spec/features/resorts/show_spec.rb
+++ b/spec/features/resorts/show_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe 'resort show page' do
 
     visit "/resorts/#{resort.id}"
     # save_and_open_page
-    click_button 'Resorts Index'
-    
+    click_on 'Resorts Index'
+
     expect(current_path).to eq('/resorts')
   end
 


### PR DESCRIPTION
What I did:  Add parent and child index links to application.html.erb (placeholders commented out for ski brands and skis routes)

Test coverage:  Feature tests "written" for corresponding view (note, unsure of proper convention to fully test routes from the application.html.erb file, tests written with two different visits and clicks for now).

Roadblocks:  See notes in test coverage

Additional notes:  Next steps are to add in any placeholder information, per note above, to fully complete iteration1, and then move on to user stories 11+ for iterations 2-3.